### PR TITLE
Bump cypress peer dependencies version.

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "rimraf": "^2.6.2"
   },
   "peerDependencies": {
-    "cypress": "^10.0.0"
+    "cypress": "^10.0.0 || ^11.0.0 || ^12.0.0"
   },
   "husky": {
     "hooks": {


### PR DESCRIPTION
@simonsmith just a minor update to hide the pesky npm dependency version warnings on a new cypress version. 