### PR TITLE
upgrade jest-image-snapshot to v6.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "chalk": "^4.1.2",
     "fs-extra": "^7.0.1",
     "glob": "^8.0.0",
-    "jest-image-snapshot": "5.0.0",
+    "jest-image-snapshot": "^6.0.0",
     "pkg-dir": "^5.0.0",
     "term-img": "^5.0.0"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -1397,7 +1397,7 @@ chalk@^3.0.0:
     ansi-styles "^4.1.0"
     supports-color "^7.1.0"
 
-chalk@^4.1.2:
+chalk@^4.0.0, chalk@^4.1.2:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-4.1.2.tgz#aac4e2b7734a740867aeb16bf02aad556a1e7a01"
   integrity sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==
@@ -3400,12 +3400,12 @@ jest-haste-map@^23.6.0:
     micromatch "^2.3.11"
     sane "^2.0.0"
 
-jest-image-snapshot@5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/jest-image-snapshot/-/jest-image-snapshot-5.0.0.tgz#17e964f1fa6e874b3f770a94d83ff5416dd2bd95"
-  integrity sha512-qbmNhe3L5a4jAJ2RqqNhh6DZnV4GBKvN7ooaKSgSAA01AdzBvrsWhf7vScZq3ELdyO9XJtD0X4/KZ2Slr6LRCg==
+jest-image-snapshot@^6.0.0:
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/jest-image-snapshot/-/jest-image-snapshot-6.1.0.tgz#96a17b00530e1358eae657f6c9bb948e29ee7510"
+  integrity sha512-LZYoks6V1HAkYqyi80gUjMWVsa++Oy0fckAGMLBQseVweZT9AmJNKAINwHLqX1fpeMy2hTG5CCEe4IUX2N3Nmg==
   dependencies:
-    chalk "^1.1.3"
+    chalk "^4.0.0"
     get-stdin "^5.0.1"
     glur "^1.1.2"
     lodash "^4.17.4"


### PR DESCRIPTION
To [support Jest v29](https://github.com/americanexpress/jest-image-snapshot/blob/main/CHANGELOG.md)