### PR TITLE
feat: add requireSnapshots configuration option

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,10 @@ Run Cypress with `--env updateSnapshots=true` in order to update the base image 
 
 Run Cypress with `--env failOnSnapshotDiff=false` in order to prevent test failures when an image diff does not pass.
 
+### Requiring snapshots to be present
+
+Run Cypress with `--env requireSnapshots=true` in order to fail if snapshots are missing. This is useful in continuous integration where snapshots should be present in advance.
+
 ### Reporter
 
 Run Cypress with `--reporter cypress-image-snapshot/reporter` in order to report snapshot diffs in your test results. This can be helpful to use with `--env failOnSnapshotDiff=false` in order to quickly view all failing snapshots and their diffs.

--- a/src/command.js
+++ b/src/command.js
@@ -9,6 +9,7 @@ import { MATCH, RECORD } from './constants';
 
 const screenshotsFolder = Cypress.config('screenshotsFolder');
 const updateSnapshots = Cypress.env('updateSnapshots') || false;
+const requireSnapshots = Cypress.env('requireSnapshots') || false;
 const failOnSnapshotDiff =
   typeof Cypress.env('failOnSnapshotDiff') === 'undefined';
 
@@ -44,6 +45,10 @@ export function matchImageSnapshotCommand(defaultOptions) {
           diffPixelCount,
           diffOutputPath,
         }) => {
+          if (added && requireSnapshots && !failOnSnapshotDiff) {
+            throw new Error(`New snapshot ${name} was added, but 'requireSnapshots' was set to true.
+            This is likely because this test was run in a CI environment in which snapshots should already be committed.`);
+          }
           if (!pass && !added && !updated) {
             const message = diffSize
               ? `Image size (${imageDimensions.baselineWidth}x${


### PR DESCRIPTION
This PR adds a configuration option that when enabled makes the test fail if the matching snapshot image is missing.

This feature was long-time requested in the `Fail test with no snapshot file` issue of the original repository:
https://github.com/jaredpalmer/cypress-image-snapshot/issues/87

And was implemented by @lexanth in this commit that I copied:
https://github.com/jaredpalmer/cypress-image-snapshot/commit/df2f147ccf9915b87565cf6d47d1d5d3632f5e3a

Since `@simonsmith/cypress-image-snapshot` seems to be the most up-to-date version of the original library I hope this feature can be implemented in this fork.

Thank you.
