### PR TITLE
fix: plugin constantly produces false positivies

### DIFF
--- a/src/plugin.js
+++ b/src/plugin.js
@@ -14,7 +14,7 @@ import { MATCH, RECORD } from './constants';
 let snapshotOptions = {};
 let snapshotResult = {};
 let snapshotRunning = false;
-const kebabSnap = '-snap.png';
+const identifierExt = '.png';
 const dotSnap = '.snap.png';
 const dotDiff = '.diff.png';
 
@@ -80,9 +80,9 @@ export function matchImageSnapshotPlugin({ path: screenshotPath }) {
     ? path.join(process.cwd(), customSnapshotsDir, specFileRelativeToRoot)
     : path.join(screenshotsFolder, '..', 'snapshots', specFileRelativeToRoot);
 
-  const snapshotKebabPath = path.join(
+  const snapshotIdentifierPath = path.join(
     snapshotsDir,
-    `${snapshotIdentifier}${kebabSnap}`
+    `${snapshotIdentifier}${identifierExt}`
   );
 
   const snapshotDotPath = path.join(
@@ -97,7 +97,7 @@ export function matchImageSnapshotPlugin({ path: screenshotPath }) {
   const diffDotPath = path.join(diffDir, `${snapshotIdentifier}${dotDiff}`);
 
   if (fs.pathExistsSync(snapshotDotPath)) {
-    fs.copySync(snapshotDotPath, snapshotKebabPath);
+    fs.copySync(snapshotDotPath, snapshotIdentifierPath);
   }
 
   snapshotResult = diffImageToSnapshot({
@@ -116,7 +116,7 @@ export function matchImageSnapshotPlugin({ path: screenshotPath }) {
   if (!pass && !added && !updated) {
     fs.copySync(diffOutputPath, diffDotPath);
     fs.removeSync(diffOutputPath);
-    fs.removeSync(snapshotKebabPath);
+    fs.removeSync(snapshotIdentifierPath);
     snapshotResult.diffOutputPath = diffDotPath;
 
     return {
@@ -124,8 +124,8 @@ export function matchImageSnapshotPlugin({ path: screenshotPath }) {
     };
   }
 
-  fs.copySync(snapshotKebabPath, snapshotDotPath);
-  fs.removeSync(snapshotKebabPath);
+  fs.copySync(snapshotIdentifierPath, snapshotDotPath);
+  fs.removeSync(snapshotIdentifierPath);
   snapshotResult.diffOutputPath = snapshotDotPath;
 
   return {


### PR DESCRIPTION
Since 6.1.0 we started seeing additional `.png` files created alongside `.snap.png` files after each run. 

This is connected to https://github.com/simonsmith/cypress-image-snapshot/pull/5 which brought in jest-image-snapshot  version 6, and particularly [this change there](https://github.com/americanexpress/jest-image-snapshot/commit/775ac0a7dff33da9719b1dc36b9e382dc10a82a1#diff-bfe9874d239014961b1ae4e89875a6155667db834a410aaaa2ebe3cf89820556L198-R198)