### PR TITLE
fix: rename e2eSpecFolder -> e2eSpecDir

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,12 +141,12 @@ generated screenshots. This means that it is difficult to mimic the folder
 structure found in the `cypress/e2e/` directory when creating the `snapshots`
 directory.
 
-To workaround this, cypress-image-snapshot makes use of a `e2eSpecFolder`
+To workaround this, cypress-image-snapshot makes use of a `e2eSpecDir`
 option. Here's an example:
 
 ```ts
 addMatchImageSnapshotCommand({
-  e2eSpecFolder: 'cypress/e2e/' // the default value
+  e2eSpecDir: 'cypress/e2e/' // the default value
 })
 ```
 
@@ -171,7 +171,7 @@ cypress
 │     └── some other test taking a snapshot.snap.png
 ```
 
-Without the `e2eSpecFolder` option the `cypress/e2e/` directories would be
+Without the `e2eSpecDir` option the `cypress/e2e/` directories would be
 repeated inside the `snapshots` directory. Set this option to whatever
 directory structure is inside the `specPattern` [configuration value](https://docs.cypress.io/guides/references/configuration#e2e). 
 

--- a/src/command.ts
+++ b/src/command.ts
@@ -18,7 +18,7 @@ const defaultOptions: SnapshotOptions = {
   isUpdateSnapshots,
   isSnapshotDebug,
   specFileRelativeToRoot: Cypress.spec.relative,
-  e2eSpecFolder: 'cypress/e2e/',
+  e2eSpecDir: 'cypress/e2e/',
   currentTestTitle: '',
   failureThreshold: 0,
   failureThresholdType: 'pixel',
@@ -141,6 +141,10 @@ const getNameAndOptions = (
       defaultOptionsOverrides,
       nameOrCommandOptions,
     ) as SnapshotOptions
+  }
+  // temporary backwards compatibility, e2eSpecFolder is deprecated
+  if (options.e2eSpecFolder) {
+    options.e2eSpecDir = options.e2eSpecFolder
   }
   return {
     filename,

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -68,10 +68,10 @@ const runImageDiffAfterScreenshot = async (
     customSnapshotsDir,
     specFileRelativeToRoot,
     customDiffDir,
-    e2eSpecFolder,
+    e2eSpecDir,
   } = options
 
-  const specDestination = specFileRelativeToRoot.replace(e2eSpecFolder, '')
+  const specDestination = specFileRelativeToRoot.replace(e2eSpecDir, '')
 
   const snapshotsDir = customSnapshotsDir
     ? path.join(process.cwd(), customSnapshotsDir, specDestination)

--- a/src/types.ts
+++ b/src/types.ts
@@ -23,7 +23,8 @@ export type SnapshotOptions = {
   isSnapshotDebug: boolean
   specFileRelativeToRoot: string
   currentTestTitle: string
-  e2eSpecFolder: string
+  e2eSpecDir: string
+  e2eSpecFolder?: string
 } & CypressScreenshotOptions &
   MatchImageSnapshotOptions
 
@@ -34,7 +35,14 @@ export type SnapshotOptions = {
 // API non breaking
 export type CypressImageSnapshotOptions = Partial<
   CypressScreenshotOptions & MatchImageSnapshotOptions
-> & {e2eSpecFolder?: string}
+> & {
+  /**
+   * @deprecated
+   * use `e2eSpecDir` instead
+   */
+  e2eSpecFolder?: string
+  e2eSpecDir?: string
+}
 
 export type Subject =
   | void


### PR DESCRIPTION
This was an error, but have left `e2eSpecFolder` as a deprecated option to prevent another major release being needed