### PR TITLE
fix: remove attempt suffix from snapshot name

### DIFF
--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -78,7 +78,10 @@ const runImageDiffAfterScreenshot = async (
       // In open mode it's an empty string so is ignored
       .replace(screenshotsFolder, ''),
   )
-  snapshotName = path.join(dirName, snapshotName)
+  snapshotName = path
+    .join(dirName, snapshotName)
+    .replace(/ \(attempt [0-9]+\)/, '')
+
   log('snapshotName', snapshotName)
   log('screenshotConfig', screenshotConfig)
 


### PR DESCRIPTION
A regression created in https://github.com/simonsmith/cypress-image-snapshot/commit/ef49519795daf5183f4fac6f3136e194f20f39f4

Fixes #19