### PR TITLE
docs: update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ Ensure that the types are included in your `tsconfig.json`
   "compilerOptions": {
     // ...
   },
-  "include": ["@simonsmith/cypress-image-snapshot/types"]
+  "types": ["@simonsmith/cypress-image-snapshot/types"]
 }
 ```
 


### PR DESCRIPTION
I had to add the type definitions to `types` for my project.

Shouldn't it be done like that in general, or am I missing something?