### PR TITLE
fix: if Cypress env `failOnSnapshotDiff` is `true`, `isFailOnSnapshotDiff` is `true`

### DIFF
--- a/src/command.ts
+++ b/src/command.ts
@@ -48,7 +48,8 @@ const matchImageSnapshot =
     commandOptions?: CypressImageSnapshotOptions,
   ) => {
     // access the env here so that it can be overridden in tests
-    const isFailOnSnapshotDiff: boolean = Cypress.env('failOnSnapshotDiff') !== false
+    const isFailOnSnapshotDiff: boolean =
+      Cypress.env('failOnSnapshotDiff') !== false
     const isRequireSnapshots: boolean = Cypress.env('requireSnapshots') || false
 
     const {filename, options} = getNameAndOptions(

--- a/src/command.ts
+++ b/src/command.ts
@@ -48,8 +48,7 @@ const matchImageSnapshot =
     commandOptions?: CypressImageSnapshotOptions,
   ) => {
     // access the env here so that it can be overridden in tests
-    const isFailOnSnapshotDiff: boolean =
-      typeof Cypress.env('failOnSnapshotDiff') === 'undefined' || false
+    const isFailOnSnapshotDiff: boolean = Cypress.env('failOnSnapshotDiff') !== false
     const isRequireSnapshots: boolean = Cypress.env('requireSnapshots') || false
 
     const {filename, options} = getNameAndOptions(


### PR DESCRIPTION
Issue reported [here](https://github.com/simonsmith/cypress-image-snapshot/issues/22)