### PR TITLE
fix(command.ts): align order of variables with error message

### DIFF
--- a/src/command.ts
+++ b/src/command.ts
@@ -96,7 +96,7 @@ const matchImageSnapshot =
 
       if (!pass && !added && !updated) {
         const message = diffSize
-          ? `Image size (${imageDimensions.baselineWidth}x${imageDimensions.baselineHeight}) different than saved snapshot size (${imageDimensions.receivedWidth}x${imageDimensions.receivedHeight}).\nSee diff for details: ${diffOutputPath}`
+          ? `Image size (${imageDimensions.receivedWidth}x${imageDimensions.receivedHeight}) different than saved snapshot size (${imageDimensions.baselineWidth}x${imageDimensions.baselineHeight}).\nSee diff for details: ${diffOutputPath}`
           : `Image was ${
               diffRatio * 100
             }% different from saved snapshot with ${diffPixelCount} different pixels.\nSee diff for details: ${diffOutputPath}`


### PR DESCRIPTION
I spent a lot of time debugging failed snapshot tests until I found out that the variables for expected and observed image dimensions are swapped in the error message. Can be tested by updating the snapshot and then checking which values change in the message. Fix is to just put them in the correct order.