### PR TITLE
fix: allowSizeMismatch error messaging

### DIFF
--- a/src/command.ts
+++ b/src/command.ts
@@ -96,11 +96,12 @@ const matchImageSnapshot =
       }
 
       if (!pass && !added && !updated) {
-        const message = diffSize
-          ? `Image size (${imageDimensions.receivedWidth}x${imageDimensions.receivedHeight}) different than saved snapshot size (${imageDimensions.baselineWidth}x${imageDimensions.baselineHeight}).\nSee diff for details: ${diffOutputPath}`
-          : `Image was ${
-              diffRatio * 100
-            }% different from saved snapshot with ${diffPixelCount} different pixels.\nSee diff for details: ${diffOutputPath}`
+        const message =
+          diffSize && !options.allowSizeMismatch
+            ? `Image size (${imageDimensions.receivedWidth}x${imageDimensions.receivedHeight}) different than saved snapshot size (${imageDimensions.baselineWidth}x${imageDimensions.baselineHeight}).\nSee diff for details: ${diffOutputPath}`
+            : `Image was ${
+                diffRatio * 100
+              }% different from saved snapshot with ${diffPixelCount} different pixels.\nSee diff for details: ${diffOutputPath}`
 
         if (isFailOnSnapshotDiff) {
           throw new Error(message)


### PR DESCRIPTION
- Produces more accurate error messaging regarding image size diffs
  - My team had some initial confusion as to why snapshot testing failed and the error messaging about image size was a red herring
- Saw this comment https://github.com/jaredpalmer/cypress-image-snapshot/issues/137#issuecomment-822616706