### PR TITLE
Fix exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,19 +18,19 @@
   "exports": {
     ".": {
       "types": "./dist/plugin.d.ts",
-      "require": "./dist/plugin.js"
+      "import": "./dist/plugin.js"
     },
     "./plugin": {
       "types": "./dist/plugin.d.ts",
-      "require": "./dist/plugin.js"
+      "import": "./dist/plugin.js"
     },
     "./command": {
       "types": "./dist/command.d.ts",
-      "require": "./dist/command.js"
+      "import": "./dist/command.js"
     },
     "./types": {
       "types": "./dist/types.d.ts",
-      "require": "./dist/types.js"
+      "import": "./dist/types.js"
     }
   },
   "typesVersions": {


### PR DESCRIPTION
Exports were defined as CJS `require` instead of ESM `import`.