### PR TITLE
fix: update jest-image-snapshot types to remove jest namespace

### DIFF
--- a/package.json
+++ b/package.json
@@ -103,8 +103,9 @@
     "cypress": ">13.0.0"
   },
   "dependencies": {
-    "@types/jest-image-snapshot": "^6.4.0",
+    "@types/pixelmatch": "^5.2.6",
     "chalk": "^4.1.2",
-    "jest-image-snapshot": "^6.5.1"
+    "jest-image-snapshot": "^6.5.1",
+    "ssim.js": "^3.5.0"
   }
 }

--- a/src/jest-image-snapshot-types.ts
+++ b/src/jest-image-snapshot-types.ts
@@ -1,0 +1,127 @@
+import type {PixelmatchOptions} from 'pixelmatch'
+import type {Options as SSIMOptions} from 'ssim.js'
+
+export interface MatchImageSnapshotOptions {
+  /**
+   * If set to true, the build will not fail when the screenshots to compare have different sizes.
+   * @default false
+   */
+  allowSizeMismatch?: boolean | undefined
+  /**
+   * Sets the max number of bytes for stdout/stderr when running diff-snapshot in a child process.
+   * @default 10 * 1024 * 1024 (10,485,760)
+   */
+  maxChildProcessBufferSizeInBytes?: number | undefined
+  /**
+   * Custom config passed to 'pixelmatch' or 'ssim'
+   */
+  customDiffConfig?: PixelmatchOptions | Partial<SSIMOptions> | undefined
+  /**
+   * The method by which images are compared.
+   * `pixelmatch` does a pixel by pixel comparison, whereas `ssim` does a structural similarity comparison.
+   * @default 'pixelmatch'
+   */
+  comparisonMethod?: 'pixelmatch' | 'ssim' | undefined
+  /**
+   * Custom snapshots directory.
+   * Absolute path of a directory to keep the snapshot in.
+   */
+  customSnapshotsDir?: string | undefined
+  /**
+   * A custom absolute path of a directory to keep this diff in
+   */
+  customDiffDir?: string | undefined
+  /**
+   * Store the received images separately from the composed diff images on failure.
+   * This can be useful when updating baseline images from CI.
+   * @default false
+   */
+  storeReceivedOnFailure?: boolean | undefined
+  /**
+   * A custom absolute path of a directory to keep this received image in.
+   */
+  customReceivedDir?: string | undefined
+  /**
+   * A custom postfix which is added to the snapshot name of the received image
+   * @default '-received'
+   */
+  customReceivedPostfix?: string | undefined
+  /**
+   * A custom name to give this snapshot. If not provided, one is computed automatically. When a function is provided
+   * it is called with an object containing testPath, currentTestName, counter and defaultIdentifier as its first
+   * argument. The function must return an identifier to use for the snapshot.
+   */
+  customSnapshotIdentifier?:
+    | ((parameters: {
+        testPath: string
+        currentTestName: string
+        counter: number
+        defaultIdentifier: string
+      }) => string)
+    | string
+    | undefined
+  /**
+   * Changes diff image layout direction.
+   * @default 'horizontal'
+   */
+  diffDirection?: 'horizontal' | 'vertical' | undefined
+  /**
+   * Either only include the difference between the baseline and the received image in the diff image, or include
+   * the 3 images (following the direction set by `diffDirection`).
+   * @default false
+   */
+  onlyDiff?: boolean | undefined
+  /**
+   * This needs to be set to a existing file, like `require.resolve('./runtimeHooksPath.cjs')`.
+   * This file can expose a few hooks:
+   * - `onBeforeWriteToDisc`: before saving any image to the disc, this function will be called (can be used to write EXIF data to images for instance)
+   * - `onBeforeWriteToDisc: (arguments: { buffer: Buffer; destination: string; testPath: string; currentTestName: string }) => Buffer`
+   */
+  runtimeHooksPath?: string | undefined
+  /**
+   * Will output base64 string of a diff image to console in case of failed tests (in addition to creating a diff image).
+   * This string can be copy-pasted to a browser address string to preview the diff for a failed test.
+   * @default false
+   */
+  dumpDiffToConsole?: boolean | undefined
+  /**
+   * Will output the image to the terminal using iTerm's Inline Images Protocol.
+   * If the term is not compatible, it does the same thing as `dumpDiffToConsole`.
+   * @default false
+   */
+  dumpInlineDiffToConsole?: boolean | undefined
+  /**
+   * Removes coloring from the console output, useful if storing the results to a file.
+   * @default false.
+   */
+  noColors?: boolean | undefined
+  /**
+   * Sets the threshold that would trigger a test failure based on the failureThresholdType selected. This is different
+   * to the customDiffConfig.threshold above - the customDiffConfig.threshold is the per pixel failure threshold, whereas
+   * this is the failure threshold for the entire comparison.
+   * @default 0.
+   */
+  failureThreshold?: number | undefined
+  /**
+   * Sets the type of threshold that would trigger a failure.
+   * @default 'pixel'.
+   */
+  failureThresholdType?: 'pixel' | 'percent' | undefined
+  /**
+   * Updates a snapshot even if it passed the threshold against the existing one.
+   * @default false.
+   */
+  updatePassedSnapshot?: boolean | undefined
+  /**
+   * Applies Gaussian Blur on compared images, accepts radius in pixels as value. Useful when you have noise after
+   * scaling images per different resolutions on your target website, usually setting its value to 1-2 should be
+   * enough to solve that problem.
+   * @default 0.
+   */
+  blur?: number | undefined
+  /**
+   * Runs the diff in process without spawning a child process.
+   * @default false.
+   */
+  runInProcess?: boolean | undefined
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,4 @@
-import type {MatchImageSnapshotOptions} from 'jest-image-snapshot'
+import type {MatchImageSnapshotOptions} from './jest-image-snapshot-types'
 
 declare global {
   namespace Cypress {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1240,8 +1240,8 @@ __metadata:
     "@types/eslint": ^8.56.12
     "@types/eslint-config-prettier": ^6.11.3
     "@types/jest": ^29.5.14
-    "@types/jest-image-snapshot": ^6.4.0
     "@types/node": ^22.16.5
+    "@types/pixelmatch": ^5.2.6
     "@types/prettier": ^3.0.0
     "@typescript-eslint/eslint-plugin": ^8.38.0
     "@typescript-eslint/parser": ^8.38.0
@@ -1257,6 +1257,7 @@ __metadata:
     prettier: ^3.6.2
     replace-json-property: ^1.9.0
     semantic-release: ^24.2.7
+    ssim.js: ^3.5.0
     typescript: 5.7.3
   peerDependencies:
     cypress: ">13.0.0"
@@ -1390,27 +1391,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/jest-image-snapshot@npm:^6.4.0":
-  version: 6.4.0
-  resolution: "@types/jest-image-snapshot@npm:6.4.0"
-  dependencies:
-    "@types/jest": "*"
-    "@types/pixelmatch": "*"
-    ssim.js: ^3.1.1
-  checksum: db751a487f3a8aef7a6f7d4209378fb147670a8d5f7bb08739426ce6cc6a034bc02dca12b9eefcb7a9fe0deec4dc0a809d436445ca405d3e796d6058da4e0568
-  languageName: node
-  linkType: hard
-
-"@types/jest@npm:*":
-  version: 29.5.1
-  resolution: "@types/jest@npm:29.5.1"
-  dependencies:
-    expect: ^29.0.0
-    pretty-format: ^29.0.0
-  checksum: 0a22491dec86333c0e92b897be2c809c922a7b2b0aa5604ac369810d6b2360908b4a3f2c6892e8a237a54fa1f10ecefe0e823ec5fcb7915195af4dfe88d2197e
-  languageName: node
-  linkType: hard
-
 "@types/jest@npm:^29.5.14":
   version: 29.5.14
   resolution: "@types/jest@npm:29.5.14"
@@ -1460,12 +1440,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/pixelmatch@npm:*":
-  version: 5.2.4
-  resolution: "@types/pixelmatch@npm:5.2.4"
+"@types/pixelmatch@npm:^5.2.6":
+  version: 5.2.6
+  resolution: "@types/pixelmatch@npm:5.2.6"
   dependencies:
     "@types/node": "*"
-  checksum: 8920c3b7df22851ad69192fb7637206cb8f7dc73520f602202e36dd6f6b7701a4b56746175e7d7391ed9dc2c636d4d9bc5d7bd26fc3f1b11df1a63fb86418b91
+  checksum: 8299207286913414bfd95ac980418342f58e7bc93dc78befbd48ccab110b0341b400712f89fea2b0f0a3a4ad0b1aed18e98e26100b529abe60d4bcc14e11d2e3
   languageName: node
   linkType: hard
 
@@ -8237,7 +8217,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ssim.js@npm:^3.1.1":
+"ssim.js@npm:^3.1.1, ssim.js@npm:^3.5.0":
   version: 3.5.0
   resolution: "ssim.js@npm:3.5.0"
   checksum: 3f3a63ac8bec9c45e9f72252b786dcb4c91d7a74316b49c20e7935fd6e3869541e9324233b00eb0ab6bd15701016becd62740a5fb8c98f7b5115a9237efb2d4a


### PR DESCRIPTION
fixes #81