### PR TITLE
fix: strip numerical suffixes from snapshot filenames

### DIFF
--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -92,8 +92,7 @@ const runImageDiffAfterScreenshot = async (
 
   snapshotName = path
     .join(dirName, snapshotName)
-    .replace(/ \(attempt [0-9]+\)/, '')
-
+    .replace(/(?: \(attempt \d+\)| \(\d+\))+$/, '')
   log('snapshotName', snapshotName)
   log('screenshotConfig', screenshotConfig)
 


### PR DESCRIPTION
### Summary

This PR updates the logic for cleaning up snapshot filenames to ensure all numerical suffixes in parentheses are stripped, rather than just those specifically labeled as "attempts."

### Impact

This change ensures snapshot naming remains consistent across different environments or local runs where filenames might be appended with generic numerical suffixes, preventing unintended mismatches in visual regression tests.